### PR TITLE
remove empty file_denylist kv, closes issue #1

### DIFF
--- a/egg-valheim.json
+++ b/egg-valheim.json
@@ -12,7 +12,6 @@
     "images": [
         "bmghosting\/valheim"
     ],
-    "file_denylist": "",
     "startup": ".\/valheim_server.x86_64 -nographics -batchmode -name \"{{SERVER_NAME}}\" -port {{SERVER_PORT}} -world \"{{WORLD_NAME}}\" -password {{PASSWORD}} -public 1",
     "config": {
         "files": "{}",


### PR DESCRIPTION
Fixes an issue with egg import failing on the latest release of pterodactyl (1.2.2). Untested on other older pterodactyl versions.